### PR TITLE
🚑 修复配置类型处理逻辑

### DIFF
--- a/zhenxun/builtin_plugins/init/init_config.py
+++ b/zhenxun/builtin_plugins/init/init_config.py
@@ -46,7 +46,7 @@ def _handle_config(plugin: Plugin, exists_module: list[str]):
                     reg_config.value,
                     help=reg_config.help,
                     default_value=reg_config.default_value,
-                    type=reg_config.type,
+                    type=reg_config.type or type(reg_config.value),
                     arg_parser=reg_config.arg_parser,
                     _override=False,
                 )

--- a/zhenxun/configs/utils/models.py
+++ b/zhenxun/configs/utils/models.py
@@ -65,7 +65,7 @@ class RegisterConfig(BaseModel):
     """配置注解"""
     default_value: Any | None = None
     """默认值"""
-    type: Any = str
+    type: Any = None
     """参数类型"""
     arg_parser: Callable | None = None
     """参数解析"""


### PR DESCRIPTION
- 在 init_config.py 中，增加了对注册配置类型为空时的处理，使用配置的值类型作为默认类型
- 在 models.py 中，将 RegisterConfig 类的 type 字段默认值从 str 改为 None，以支持更灵活的配置类型