### PR TITLE
🚑fix(zhenxun): 修复初始化配置文件时的类型判断逻辑

### DIFF
--- a/zhenxun/builtin_plugins/init/init_config.py
+++ b/zhenxun/builtin_plugins/init/init_config.py
@@ -46,7 +46,7 @@ def _handle_config(plugin: Plugin, exists_module: list[str]):
                     reg_config.value,
                     help=reg_config.help,
                     default_value=reg_config.default_value,
-                    type=reg_config.type or type(reg_config.value),
+                    type=reg_config.type,
                     arg_parser=reg_config.arg_parser,
                     _override=False,
                 )

--- a/zhenxun/configs/utils/models.py
+++ b/zhenxun/configs/utils/models.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, Type  # noqa: UP035
 
 from nonebot.compat import model_dump
 from pydantic import BaseModel, Field
@@ -65,7 +65,7 @@ class RegisterConfig(BaseModel):
     """配置注解"""
     default_value: Any | None = None
     """默认值"""
-    type: Any = None
+    type: Type = str  # noqa: UP006
     """参数类型"""
     arg_parser: Callable | None = None
     """参数解析"""


### PR DESCRIPTION
- 这样可以更准确地处理配置项的类型，避免潜在的类型错误