### PR TITLE
fix(zhenxun): 修复群员昵称中包含特殊字符导致的更新异常

### DIFF
--- a/zhenxun/builtin_plugins/admin/group_member_update/_data_source.py
+++ b/zhenxun/builtin_plugins/admin/group_member_update/_data_source.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 
 import nonebot
 from nonebot.adapters import Bot
@@ -32,7 +33,9 @@ class MemberUpdateManage:
         """
         driver = nonebot.get_driver()
         default_auth = Config.get_config("admin_bot_manage", "ADMIN_DEFAULT_AUTH")
-        nickname = member.nick or member.user.name or ""
+        nickname = re.sub(
+            r"[\x00-\x09\x0b-\x1f\x7f-\x9f]", "", member.nick or member.user.name or ""
+        )
         role = member.role
         db_user_uid = [u.user_id for u in db_user]
         uid2name = {u.user_id: u.user_name for u in db_user}


### PR DESCRIPTION
- 在更新群员信息时，使用正则表达式过滤掉昵称中的控制字符
- 优化了 MemberUpdateManage 类中的代码，提高了数据的兼容性和安全性