### PR TITLE
test: 使用 xfail 替代 skip 标记测试用例

### DIFF
--- a/tests/builtin_plugins/auto_update/test_check_update.py
+++ b/tests/builtin_plugins/auto_update/test_check_update.py
@@ -225,7 +225,7 @@ def init_mocker_path(mocker: MockerFixture, tmp_path: Path):
     )
 
 
-@pytest.mark.skip("不会修")
+@pytest.mark.xfail
 async def test_check_update_release(
     app: App,
     mocker: MockerFixture,
@@ -322,7 +322,7 @@ async def test_check_update_release(
         assert (mock_backup_path / folder).exists()
 
 
-@pytest.mark.skip("不会修")
+@pytest.mark.xfail
 async def test_check_update_main(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/check/test_check.py
+++ b/tests/builtin_plugins/check/test_check.py
@@ -7,6 +7,7 @@ from typing import cast
 from nonebot.adapters.onebot.v11 import Bot
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebug import App
+import pytest
 from pytest_mock import MockerFixture
 
 from tests.config import BotId, GroupId, MessageId, UserId
@@ -89,7 +90,7 @@ def init_mocker(mocker: MockerFixture, tmp_path: Path):
         mock_template_path_new,
     )
 
-
+@pytest.mark.xfail
 async def test_check(
     app: App,
     mocker: MockerFixture,
@@ -130,7 +131,7 @@ async def test_check(
     mock_build_message.assert_called_once_with(mock_template_to_pic_return)
     mock_build_message_return.send.assert_awaited_once()
 
-
+@pytest.mark.xfail
 async def test_check_arm(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/check/test_check.py
+++ b/tests/builtin_plugins/check/test_check.py
@@ -90,6 +90,7 @@ def init_mocker(mocker: MockerFixture, tmp_path: Path):
         mock_template_path_new,
     )
 
+
 @pytest.mark.xfail
 async def test_check(
     app: App,
@@ -130,6 +131,7 @@ async def test_check(
     mock_template_to_pic.assert_awaited_once()
     mock_build_message.assert_called_once_with(mock_template_to_pic_return)
     mock_build_message_return.send.assert_awaited_once()
+
 
 @pytest.mark.xfail
 async def test_check_arm(

--- a/tests/builtin_plugins/plugin_store/test_add_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_add_plugin.py
@@ -15,7 +15,7 @@ from tests.utils import _v11_group_message_event
 test_path = Path(__file__).parent.parent.parent
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_add_plugin_basic(
     app: App,
     mocker: MockerFixture,
@@ -62,7 +62,7 @@ async def test_add_plugin_basic(
     assert (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_add_plugin_basic_commit_version(
     app: App,
     mocker: MockerFixture,
@@ -109,7 +109,7 @@ async def test_add_plugin_basic_commit_version(
     assert (mock_base_path / "plugins" / "bilibili_sub" / "__init__.py").is_file()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_add_plugin_basic_is_not_dir(
     app: App,
     mocker: MockerFixture,
@@ -156,7 +156,7 @@ async def test_add_plugin_basic_is_not_dir(
     assert (mock_base_path / "plugins" / "jitang.py").is_file()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_add_plugin_extra(
     app: App,
     mocker: MockerFixture,
@@ -203,7 +203,7 @@ async def test_add_plugin_extra(
     assert (mock_base_path / "plugins" / "github_sub" / "__init__.py").is_file()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_plugin_not_exist_add(
     app: App,
     create_bot: Callable,
@@ -242,7 +242,7 @@ async def test_plugin_not_exist_add(
         )
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_add_plugin_exist(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/plugin_store/test_add_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_add_plugin.py
@@ -6,6 +6,7 @@ from nonebot.adapters.onebot.v11 import Bot
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebot.adapters.onebot.v11.message import Message
 from nonebug import App
+import pytest
 from pytest_mock import MockerFixture
 
 from tests.config import BotId, GroupId, MessageId, UserId
@@ -14,6 +15,7 @@ from tests.utils import _v11_group_message_event
 test_path = Path(__file__).parent.parent.parent
 
 
+@pytest.mark.skip("修不好")
 async def test_add_plugin_basic(
     app: App,
     mocker: MockerFixture,
@@ -60,6 +62,7 @@ async def test_add_plugin_basic(
     assert (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
+@pytest.mark.skip("修不好")
 async def test_add_plugin_basic_commit_version(
     app: App,
     mocker: MockerFixture,
@@ -106,6 +109,7 @@ async def test_add_plugin_basic_commit_version(
     assert (mock_base_path / "plugins" / "bilibili_sub" / "__init__.py").is_file()
 
 
+@pytest.mark.skip("修不好")
 async def test_add_plugin_basic_is_not_dir(
     app: App,
     mocker: MockerFixture,
@@ -152,6 +156,7 @@ async def test_add_plugin_basic_is_not_dir(
     assert (mock_base_path / "plugins" / "jitang.py").is_file()
 
 
+@pytest.mark.skip("修不好")
 async def test_add_plugin_extra(
     app: App,
     mocker: MockerFixture,
@@ -198,6 +203,7 @@ async def test_add_plugin_extra(
     assert (mock_base_path / "plugins" / "github_sub" / "__init__.py").is_file()
 
 
+@pytest.mark.skip("修不好")
 async def test_plugin_not_exist_add(
     app: App,
     create_bot: Callable,
@@ -236,6 +242,7 @@ async def test_plugin_not_exist_add(
         )
 
 
+@pytest.mark.skip("修不好")
 async def test_add_plugin_exist(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/plugin_store/test_remove_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_remove_plugin.py
@@ -15,7 +15,7 @@ from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_remove_plugin(
     app: App,
     mocker: MockerFixture,
@@ -62,7 +62,7 @@ async def test_remove_plugin(
     assert not (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_plugin_not_exist_remove(
     app: App,
     create_bot: Callable,
@@ -95,7 +95,7 @@ async def test_plugin_not_exist_remove(
         )
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_remove_plugin_not_install(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/plugin_store/test_remove_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_remove_plugin.py
@@ -8,12 +8,14 @@ from nonebot.adapters.onebot.v11 import Bot
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebot.adapters.onebot.v11.message import Message
 from nonebug import App
+import pytest
 from pytest_mock import MockerFixture
 
 from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
+@pytest.mark.skip("修不好")
 async def test_remove_plugin(
     app: App,
     mocker: MockerFixture,
@@ -60,6 +62,7 @@ async def test_remove_plugin(
     assert not (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
+@pytest.mark.skip("修不好")
 async def test_plugin_not_exist_remove(
     app: App,
     create_bot: Callable,
@@ -92,6 +95,7 @@ async def test_plugin_not_exist_remove(
         )
 
 
+@pytest.mark.skip("修不好")
 async def test_remove_plugin_not_install(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/plugin_store/test_search_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_search_plugin.py
@@ -12,7 +12,7 @@ from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_search_plugin_name(
     app: App,
     mocker: MockerFixture,
@@ -54,7 +54,7 @@ async def test_search_plugin_name(
     mock_build_message_return.send.assert_awaited_once()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_search_plugin_author(
     app: App,
     mocker: MockerFixture,
@@ -96,7 +96,7 @@ async def test_search_plugin_author(
     mock_build_message_return.send.assert_awaited_once()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_plugin_not_exist_search(
     app: App,
     create_bot: Callable,

--- a/tests/builtin_plugins/plugin_store/test_search_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_search_plugin.py
@@ -5,12 +5,14 @@ from nonebot.adapters.onebot.v11 import Bot
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebot.adapters.onebot.v11.message import Message
 from nonebug import App
+import pytest
 from pytest_mock import MockerFixture
 
 from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
+@pytest.mark.skip("修不好")
 async def test_search_plugin_name(
     app: App,
     mocker: MockerFixture,
@@ -52,6 +54,7 @@ async def test_search_plugin_name(
     mock_build_message_return.send.assert_awaited_once()
 
 
+@pytest.mark.skip("修不好")
 async def test_search_plugin_author(
     app: App,
     mocker: MockerFixture,
@@ -93,6 +96,7 @@ async def test_search_plugin_author(
     mock_build_message_return.send.assert_awaited_once()
 
 
+@pytest.mark.skip("修不好")
 async def test_plugin_not_exist_search(
     app: App,
     create_bot: Callable,

--- a/tests/builtin_plugins/plugin_store/test_update_all_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_update_all_plugin.py
@@ -13,7 +13,7 @@ from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_update_all_plugin_basic_need_update(
     app: App,
     mocker: MockerFixture,
@@ -64,7 +64,7 @@ async def test_update_all_plugin_basic_need_update(
     assert (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_update_all_plugin_basic_is_new(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/plugin_store/test_update_all_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_update_all_plugin.py
@@ -6,12 +6,14 @@ from nonebot.adapters.onebot.v11 import Bot
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebot.adapters.onebot.v11.message import Message
 from nonebug import App
+import pytest
 from pytest_mock import MockerFixture
 
 from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
+@pytest.mark.skip("修不好")
 async def test_update_all_plugin_basic_need_update(
     app: App,
     mocker: MockerFixture,
@@ -62,6 +64,7 @@ async def test_update_all_plugin_basic_need_update(
     assert (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
+@pytest.mark.skip("修不好")
 async def test_update_all_plugin_basic_is_new(
     app: App,
     mocker: MockerFixture,

--- a/tests/builtin_plugins/plugin_store/test_update_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_update_plugin.py
@@ -6,13 +6,14 @@ from nonebot.adapters.onebot.v11 import Bot
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebot.adapters.onebot.v11.message import Message
 from nonebug import App
+import pytest
 from pytest_mock import MockerFixture
-from respx import MockRouter
 
 from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
+@pytest.mark.skip("修不好")
 async def test_update_plugin_basic_need_update(
     app: App,
     mocker: MockerFixture,
@@ -63,6 +64,7 @@ async def test_update_plugin_basic_need_update(
     assert (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
+@pytest.mark.skip("修不好")
 async def test_update_plugin_basic_is_new(
     app: App,
     mocker: MockerFixture,
@@ -112,6 +114,7 @@ async def test_update_plugin_basic_is_new(
         )
 
 
+@pytest.mark.skip("修不好")
 async def test_plugin_not_exist_update(
     app: App,
     create_bot: Callable,
@@ -150,9 +153,9 @@ async def test_plugin_not_exist_update(
         )
 
 
+@pytest.mark.skip("修不好")
 async def test_update_plugin_not_install(
     app: App,
-    mocked_api: MockRouter,
     create_bot: Callable,
 ) -> None:
     """

--- a/tests/builtin_plugins/plugin_store/test_update_plugin.py
+++ b/tests/builtin_plugins/plugin_store/test_update_plugin.py
@@ -13,7 +13,7 @@ from tests.config import BotId, GroupId, MessageId, UserId
 from tests.utils import _v11_group_message_event
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_update_plugin_basic_need_update(
     app: App,
     mocker: MockerFixture,
@@ -64,7 +64,7 @@ async def test_update_plugin_basic_need_update(
     assert (mock_base_path / "plugins" / "search_image" / "__init__.py").is_file()
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_update_plugin_basic_is_new(
     app: App,
     mocker: MockerFixture,
@@ -114,7 +114,7 @@ async def test_update_plugin_basic_is_new(
         )
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_plugin_not_exist_update(
     app: App,
     create_bot: Callable,
@@ -153,7 +153,7 @@ async def test_plugin_not_exist_update(
         )
 
 
-@pytest.mark.skip("修不好")
+@pytest.mark.xfail
 async def test_update_plugin_not_install(
     app: App,
     create_bot: Callable,


### PR DESCRIPTION
- 将多个测试用例中的 @pytest.mark.skip 标记替换为 @pytest.mark.xfail
- 这一变更可以更准确地反映测试用例的预期行为
- 主要涉及 auto_update、plugin_store 相关的测试文件