### PR TITLE
refactor(zhenxun): 移除失效的 GitHub 代理

### DIFF
--- a/zhenxun/utils/github_utils/func.py
+++ b/zhenxun/utils/github_utils/func.py
@@ -22,7 +22,6 @@ async def get_fastest_raw_formats() -> list[str]:
     """获取最快的raw下载地址格式"""
     formats: dict[str, str] = {
         "https://raw.githubusercontent.com/": RAW_CONTENT_FORMAT,
-        "https://ghproxy.cc/": f"https://ghproxy.cc/{RAW_CONTENT_FORMAT}",
         "https://gh-proxy.com/": f"https://gh-proxy.com/{RAW_CONTENT_FORMAT}",
         "https://cdn.jsdelivr.net/": "https://cdn.jsdelivr.net/gh/{owner}/{repo}@{branch}/{path}",
     }
@@ -34,7 +33,6 @@ async def get_fastest_archive_formats() -> list[str]:
     """获取最快的归档下载地址格式"""
     formats: dict[str, str] = {
         "https://github.com/": ARCHIVE_URL_FORMAT,
-        "https://ghproxy.cc/": f"https://ghproxy.cc/{ARCHIVE_URL_FORMAT}",
         "https://gh-proxy.com/": f"https://gh-proxy.com/{ARCHIVE_URL_FORMAT}",
     }
     return await __get_fastest_formats(formats)
@@ -45,7 +43,6 @@ async def get_fastest_release_formats() -> list[str]:
     """获取最快的发行版资源下载地址格式"""
     formats: dict[str, str] = {
         "https://objects.githubusercontent.com/": RELEASE_ASSETS_FORMAT,
-        "https://ghproxy.cc/": f"https://ghproxy.cc/{RELEASE_ASSETS_FORMAT}",
         "https://gh-proxy.com/": f"https://gh-proxy.com/{RELEASE_ASSETS_FORMAT}",
     }
     return await __get_fastest_formats(formats)


### PR DESCRIPTION
- 从 get_fastest_raw_formats、get_fastest_archive_formats 和 get_fastest_release_formats 函数中移除了 ghproxy.cc 代理地址