### PR TITLE
fix(shop): 修改道具不存在时的提示信息

### DIFF
--- a/zhenxun/builtin_plugins/shop/_data_source.py
+++ b/zhenxun/builtin_plugins/shop/_data_source.py
@@ -367,7 +367,7 @@ class ShopManage:
         else:
             goods_info = await GoodsInfo.get_or_none(goods_name=goods_name)
         if not goods_info:
-            return f"{goods_name} 不存在..."
+            return "对应的道具不存在..."
         if goods_info.is_passive:
             return f"{goods_info.goods_name} 是被动道具, 无法使用..."
         goods = cls.uuid2goods.get(goods_info.uuid)


### PR DESCRIPTION
- 将道具不存在时的提示信息从具体的道具名称改为通用提示，避免暴露内部实现细节，
提升用户体验和安全性。
- resolve Bug: 使用道具功能优化
Fixes #2060